### PR TITLE
Checkout source for CodeCov

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Create Release Notes
         uses: docker://decathlon/release-notes-generator-action:2.0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,8 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@v2
+
       - name: Create reports
         run: |
           mkdir reports


### PR DESCRIPTION
Codecov didn't have access to the source code because the coverage
report was run inside the container, while codecov was run outside it.
Adding the ckeckout action should solve this.

Also pinned the checkout action version in the release action.