### PR TITLE
Cancel previous workflow with new push

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,16 @@ env:
   DOCKER_REGISTRY_URL: docker.pkg.github.com
   DOCKER_BUILDKIT: 1
 jobs:
+  cancel:
+    name: Cancel previous workflow on same branch
+    runs-on: ubuntu-18.04
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.3.1
+        with:
+          workflow_id: 1177419
+          access_token: ${{ github.token }}
+
   createImages:
     name: Create test docker images
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Cancels the previous jobs on the workflow for the same branch with a
different SHA. Only applies to the test.yaml workflow.